### PR TITLE
Fix option duplication in question component

### DIFF
--- a/src/components/Question.tsx
+++ b/src/components/Question.tsx
@@ -20,17 +20,17 @@ const Question: React.FC<QuestionProps> = ({ question, onAnswer, showAnswer }) =
         {question.options.map((option, index) => (
           <button
             key={index}
-            onClick={() => !showAnswer && onAnswer(String.fromCharCode(65 + index))}
+            onClick={() => !showAnswer && onAnswer(option)}
             className={`option-button ${
               showAnswer
-                ? String.fromCharCode(65 + index) === question.correctAnswer
+                ? option === question.correctAnswer
                   ? 'correct'
                   : 'incorrect'
                 : ''
             }`}
             disabled={showAnswer}
           >
-            {String.fromCharCode(65 + index)}. {option}
+            {option}
           </button>
         ))}
       </div>


### PR DESCRIPTION
Remove the duplicate option letter from the response options in the `Question` component.

* Modify `src/components/Question.tsx` to use the `option` text directly in the `option-button`.
* Remove the additional appending of the option letter in the `option-button` text.
* Update the `onClick` handler to use the `option` text instead of the option letter.

